### PR TITLE
Update devcontainer name to data-platform

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "analytical-platform-visual-studio-code",
+  "name": "data-platform",
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:": {}


### PR DESCRIPTION
## Proposed Changes

- Updated devcontainer name from 'analytical-platform-visual-studio-code' to 'data-platform'

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>