### PR TITLE
:dependabot: Correct Dependabot syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       prefix: ":dependabot: devcontainers"
     cooldown:
       default-days: 7
-      excludes:
+      exclude:
         - "ghcr.io/ministryofjustice/devcontainer-feature/*"
     directory: "/"
     open-pull-requests-limit: 15
@@ -20,7 +20,7 @@ updates:
       prefix: ":dependabot: github-actions"
     cooldown:
       default-days: 7
-      excludes:
+      exclude:
         - "ministryofjustice/action*"
         - "ministryofjustice/data-platform-github-actions*"
     directory: "/"


### PR DESCRIPTION
## Proposed Changes

- Should fix

```
The property '#/updates/0/cooldown' contains additional properties ["excludes"] outside of the schema when none are allowed
The property '#/updates/1/cooldown' contains additional properties ["excludes"] outside of the schema when none are allowed
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>