### PR TITLE
:dependabot: Remove cooldown option from pre-commit ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,12 +31,10 @@ updates:
     open-pull-requests-limit: 15
     schedule:
       interval: "daily"
-  - package-ecosystem: "pre-commit"
+  - package-ecosystem: "pre-commit" # zizmor: ignore[dependabot-cooldown]
     commit-message:
       include: "scope"
       prefix: ":dependabot: pre-commit"
-    cooldown:
-      default-days: 7
     directory: "/"
     open-pull-requests-limit: 15
     schedule:


### PR DESCRIPTION
## Proposed Changes

- Removes cooldown from pre-commit ecosystem, see notes
- Adds an Zizmor ignore for the lock of cooldown option

## Notes

After merging #89, the following was observed:

<img width="747" height="330" alt="Screenshot 2026-03-11 at 09 14 52" src="https://github.com/user-attachments/assets/24bfdbc2-2b3d-4454-9bdd-658d42096901" />

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>