### PR TITLE
🎡 Align dev container configuration

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -10,7 +10,7 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/astral:1": {
+    "ghcr.io/ministryofjustice/devcontainer-feature/astral:": {
       "version": "1.0.0",
       "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/astral@sha256:a6df118c6475e79fe15e63b815a5df591a24b0d25517ea941114cb6bee1af9a8",
       "integrity": "sha256:a6df118c6475e79fe15e63b815a5df591a24b0d25517ea941114cb6bee1af9a8"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:": {},
     "ghcr.io/devcontainers/features/github-cli:": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/astral:1": {}
+    "ghcr.io/ministryofjustice/devcontainer-feature/astral:": {}
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Proposed Changes

- Aligns dev container configuration to use `<feature>:` syntax

## Notes

In https://github.com/ministryofjustice/data-platform/pull/89 I updated the config to use a "normal" looking syntax, but Dependabot reversed that in https://github.com/ministryofjustice/data-platform/pull/91 and https://github.com/ministryofjustice/data-platform/pull/92

I will defer this to Dependabot's judgement as its the one updating the lockfile

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>