### PR TITLE
📝 Remove reference to in-house pre-commit updater

### DIFF
--- a/source/getting-started/developing/index.html.md.erb
+++ b/source/getting-started/developing/index.html.md.erb
@@ -15,7 +15,6 @@ Additionally, all our repositories include a baseline set of GitHub Actions:
 - [CodeQL Analysis](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/codeql-analysis.md)
 - [Dependency Review](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/dependency-review.md)
 - [OpenSSF Scorecard](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/openssf-scorecard.md) (only if it's a public repository)
-- [pre-commit Updater](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/pre-commit-updater.md)
 - [Spell Check](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/spell-check.md)
 - [Super Linter](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/super-linter.md)
 - [Zizmor](https://github.com/ministryofjustice/data-platform-github-actions/blob/main/docs/usage/workflows/zizmor.md)


### PR DESCRIPTION
## Proposed Changes

- Removes reference to in-house pre-commit updater now that it's Dependabot native

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>